### PR TITLE
Fix build error: no member named 'setprecision' in namespace 'std'

### DIFF
--- a/src/mythic_affix.cpp
+++ b/src/mythic_affix.cpp
@@ -5,6 +5,7 @@
 #include "Creature.h"
 #include "mythic_plus.h"
 #include "mythic_affix.h"
+#include <iomanip>
 
 /*static*/ bool MythicAffix::IsCreatureProcessed(Creature* creature)
 {

--- a/src/mythic_plus.cpp
+++ b/src/mythic_plus.cpp
@@ -8,6 +8,7 @@
 #include "Config.h"
 #include "mythic_affix.h"
 #include "mythic_plus.h"
+#include <iomanip>
 
 MythicPlus::MythicPlus()
 {


### PR DESCRIPTION
```
/azerothcore-wotlk/modules/mod-mythic-plus/src/mythic_affix.cpp:75:31: fatal error: no member named 'setprecision' in namespace 'std'
    oss << std::fixed << std::setprecision(2) << healthMod * 100 << "% for ";
```